### PR TITLE
Feature/#53 trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,5 @@ jobs:
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         packages-dir: dist
-        verbose: true
 
 # for testing publication: use `uv publish --publish-url https://test.pypi.org/legacy`. Ask for the test token. (user mirai-solutions-gmbh on test.pypi.org)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: published
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -13,11 +13,28 @@ jobs:
       with:
         enable-cache: true
         python-version: 3.12
-    - name: Build and publish
-      env:
-        UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        uv build --wheel
-        uv publish
+    - name: Build wheel
+      run: uv build --wheel
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/*.whl
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
+    - name: pypi-publish
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      with:
+        packages-dir: dist
 
 # for testing publication: use `uv publish --publish-url https://test.pypi.org/legacy`. Ask for the test token. (user mirai-solutions-gmbh on test.pypi.org)

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,8 +1,7 @@
-name: Upload Python Package to PyPI
+name: TEST Upload Python Package to PyPI
 
 on:
-  release:
-    types: published
+    workflow_dispatch:
 
 jobs:
   build:
@@ -36,6 +35,6 @@ jobs:
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         packages-dir: dist
-        verbose: true
+        repository-url: https://test.pypi.org/legacy/
 
 # for testing publication: use `uv publish --publish-url https://test.pypi.org/legacy`. Ask for the test token. (user mirai-solutions-gmbh on test.pypi.org)

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -36,5 +36,6 @@ jobs:
       with:
         packages-dir: dist
         repository-url: https://test.pypi.org/legacy/
+        verbose: true
 
 # for testing publication: use `uv publish --publish-url https://test.pypi.org/legacy`. Ask for the test token. (user mirai-solutions-gmbh on test.pypi.org)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     'Topic :: Games/Entertainment',
 ]
 license = "MIT"
-version = "0.1.dev1"
+version = "0.1.dev2"
 keywords = ["secret", "santa"]
 requires-python = ">=3.9"
 dependencies = ["click", "numpy"]


### PR DESCRIPTION
will close #53 
includes a test workflow to be triggered manually for testing changes to publication logic. It seems safer and more flexible to use a different workflow entirely, avoiding publishing to the wrong pypi instance.