### PR TITLE
Update setup-uv version comments to v8.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v7.3.0; prevent CWE-829
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0; prevent CWE-829
       with:
         enable-cache: true
         python-version: 3.14

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
       matrix: { python-version: ["3.10","3.11","3.12","3.13","3.14"] }
     steps:
     - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v7.3.0; prevent CWE-829
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0; prevent CWE-829
       with:
         enable-cache: true
         python-version: ${{ matrix.python-version }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v7.3.0; prevent CWE-829
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0; prevent CWE-829
       with:
         enable-cache: true
         python-version: 3.12

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v7.3.0; prevent CWE-829
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0; prevent CWE-829
       with:
         enable-cache: true
         python-version: 3.14


### PR DESCRIPTION
This PR updates the version comments for the `astral-sh/setup-uv` action in GitHub workflow files. The previous comments incorrectly identified hash `08807647e7069bb48b6ef5acd8ec9567f424441b` as `v7.3.0`, whereas it corresponds to `v8.1.0`.

Changes:
- Updated `.github/workflows/python-package.yml`
- Updated `.github/workflows/test-publish.yml`
- Updated `.github/workflows/publish.yml`

All functional tests and lints were verified to pass.

---
*PR created automatically by Jules for task [9992055171697887972](https://jules.google.com/task/9992055171697887972) started by @spoltier*