### PR TITLE
Upgrade codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run documentation tests
       run: uv run nox -s doctest
     
-    - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+    - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)


### PR DESCRIPTION
Upgraded `codecov/codecov-action` from `v6.0.1` to `v7.0.0` (pinned to commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f`) in `.github/workflows/python-package.yml`. This upgrade resolves the GPG verification failure associated with Codecov's Keybase account migration (issue #1956). All project tests and linters passed successfully after the change.

---
*PR created automatically by Jules for task [1935426967146804152](https://jules.google.com/task/1935426967146804152) started by @spoltier*